### PR TITLE
Reimplement web links for handles

### DIFF
--- a/src/screens/Profile/Header/Handle.tsx
+++ b/src/screens/Profile/Header/Handle.tsx
@@ -6,7 +6,9 @@ import {useLingui} from '@lingui/react'
 import {isInvalidHandle, sanitizeHandle} from '#/lib/strings/handles'
 import {isIOS, isNative} from '#/platform/detection'
 import {type Shadow} from '#/state/cache/types'
+import {useShowLinkInHandle} from '#/state/preferences/show-link-in-handle.tsx'
 import {atoms as a, useTheme, web} from '#/alf'
+import {InlineLinkText} from '#/components/Link.tsx'
 import {NewskieDialog} from '#/components/NewskieDialog'
 import {Text} from '#/components/Typography'
 
@@ -21,6 +23,14 @@ export function ProfileHeaderHandle({
   const {_} = useLingui()
   const invalidHandle = isInvalidHandle(profile.handle)
   const blockHide = profile.viewer?.blocking || profile.viewer?.blockedBy
+  const isBskySocialHandle = profile.handle.endsWith('.bsky.social')
+  const showProfileInHandle = useShowLinkInHandle()
+  const sanitized = sanitizeHandle(
+    profile.handle,
+    '@',
+    // forceLTR handled by CSS above on web
+    isNative,
+  )
   return (
     <View
       style={[a.flex_row, a.gap_sm, a.align_center, {maxWidth: '100%'}]}
@@ -53,14 +63,19 @@ export function ProfileHeaderHandle({
             unicodeBidi: 'isolate',
           }),
         ]}>
-        {invalidHandle
-          ? _(msg`⚠Invalid Handle`)
-          : sanitizeHandle(
-              profile.handle,
-              '@',
-              // forceLTR handled by CSS above on web
-              isNative,
-            )}
+        {invalidHandle ? (
+          _(msg`⚠Invalid Handle`)
+        ) : showProfileInHandle && !isBskySocialHandle ? (
+          <InlineLinkText
+            to={`https://${profile.handle}`}
+            label={profile.handle}>
+            <Text style={[a.text_md, {color: t.palette.primary_500}]}>
+              {sanitized}
+            </Text>
+          </InlineLinkText>
+        ) : (
+          sanitized
+        )}
       </Text>
     </View>
   )


### PR DESCRIPTION
The actual code for this tweak was seemingly removed at some point. This should restore it.